### PR TITLE
handle weird cases in networking, UBC sends + device ID hashing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,4 +162,4 @@ cython_debug/
 profiles_settings.xml
 project_default.xml
 
-config.json
+config.toml

--- a/server/communication/rec_communication.py
+++ b/server/communication/rec_communication.py
@@ -82,6 +82,16 @@ class RecCommunication:
         
         return Status,msg
     
+    def CreateRecInteractionAck(self,interaction_id:int, valid:bool, reason:str):
+        msg = rec_proto.RECInteractionAck()
+        msg.interaction_id = interaction_id
+        msg.success = valid
+        msg.result_data = reason.encode()
+
+        def_message = self.CreateDefaultRecMessage(rec_proto.RECMessageType.REC_INTERACTION_ACK)
+        def_message.interaction_ack.CopyFrom(msg)
+        return def_message
+    
     def RecServerInfo(self,player_count:int):
         major_version = config.config["server_major_version"]
         minor_version = config.config["server_minor_version"]

--- a/server/communication/ubc_communication.py
+++ b/server/communication/ubc_communication.py
@@ -1,5 +1,6 @@
 import server.protocols.ubc_pb2 as ubc_proto
 import server.devices as devices
+import google.protobuf.any as protobuf
 
 class UbcCommunication:
     def __init__(self):
@@ -34,4 +35,8 @@ class UbcCommunication:
         msg.session_id = session_id
         msg.payloads.extend(payloads)
 
-        return msg
+        any = protobuf.Any()
+
+        any.Pack(msg)
+
+        return any

--- a/server/devices.py
+++ b/server/devices.py
@@ -3,7 +3,7 @@ from typing import Union, Optional
 from dataclasses import dataclass
 from abc import ABC
 from enum import IntEnum
-import hashlib
+import xxhash
 import server.protocols.ubc_pb2 as ubc_pb2
 DeviceFieldValue = Union[str, int, float, bool, bytes]
 @dataclass
@@ -26,7 +26,7 @@ class StateChangeResult(IntEnum):
 
 class DeviceBase(ABC):
     def __init__(self, device_type: str, name: str):
-        self._device_id = np.ulonglong(int(hashlib.sha256(name.encode()).hexdigest(), 16) % (2**64))
+        self._device_id = np.ulonglong(xxhash.xxh64(name.encode()).intdigest())
         self._device_type = device_type
         self._is_dirty = False
         self._fields: list[DeviceField] = []
@@ -74,7 +74,7 @@ class DeviceBase(ABC):
             print("Wrong field type %d" % field_id)
             return StateChangeResult.INVALID_VALUE
 
-        changed_value = field.value != new_value
+        changed_value = True #field.value != new_value
         field.value = new_value
         if changed_value:
             self._is_dirty = True

--- a/server/devices.py
+++ b/server/devices.py
@@ -3,6 +3,7 @@ from typing import Union, Optional
 from dataclasses import dataclass
 from abc import ABC
 from enum import IntEnum
+from events import Events
 import xxhash
 import server.protocols.ubc_pb2 as ubc_pb2
 DeviceFieldValue = Union[str, int, float, bool, bytes]
@@ -74,7 +75,7 @@ class DeviceBase(ABC):
             print("Wrong field type %d" % field_id)
             return StateChangeResult.INVALID_VALUE
 
-        changed_value = True #field.value != new_value
+        changed_value = field.value != new_value
         field.value = new_value
         if changed_value:
             self._is_dirty = True
@@ -86,6 +87,7 @@ class DeviceBase(ABC):
 class DeviceRegistry:
     _instance: "DeviceRegistry" = None
     _devices: dict[np.ulonglong, "DeviceBase"]
+    OnInteractionComplete = Events()
     def __new__(cls) -> "DeviceRegistry":
         if cls._instance is None:
             cls._instance = super().__new__(cls)
@@ -155,4 +157,7 @@ def on_interaction(client, message):
     data = ubc_pb2.UBCMessage.Payload.Data()
     data.ParseFromString(interaction.data)
 
-    device.on_interaction(interaction_id, interaction_type, data)
+    valid,reason = device.on_interaction(interaction_id, interaction_type, data)
+
+    REGISTRY.OnInteractionComplete.on_changed(client,interaction_id,valid,reason)
+        

--- a/server/example/simulation_module.py
+++ b/server/example/simulation_module.py
@@ -9,12 +9,17 @@ class SBMBreaker(devices.DeviceBase):
 
     def on_interaction(self, interaction_id, interaction_type, data):
         value = getattr(data,data.WhichOneof("data"))
+
+        if data.field == 0 and value > 2 or value < 0: return (False, "Invalid switch position")
+
         self.set_field_value(data.field,value)
 
         if self.get_field_by_id(0).value == 0: #switch flag
             self.set_field_value(1,0)
         elif self.get_field_by_id(0).value == 2:
             self.set_field_value(1,1)
+
+        return (True, "")
 
 class PositionType(Enum):
     Momentary = 0,

--- a/server/session_mgt.py
+++ b/server/session_mgt.py
@@ -38,6 +38,8 @@ class SessionManager:
 
         self.counter_sessionid = 1 #start at 1 to prevent giving out session ID 0
 
+        devices.REGISTRY.OnInteractionComplete.on_changed += self.HandleInteractionAck
+
 
 
     def ProcessDataRec(self,data,address):
@@ -113,7 +115,12 @@ class SessionManager:
 
                 msg = rec_communication.RecServerInfo(player_count)
                 client.Send(msg)
-                
+
+    def HandleInteractionAck(self,client,id,valid,reason):
+        msg = rec_communication.CreateRecInteractionAck(id,valid,reason)
+
+        client.Send(msg)
+
     def ProcessDataUBC(self,data,address):
         Heartbeat = common_proto.Heartbeat()
 

--- a/server/session_mgt.py
+++ b/server/session_mgt.py
@@ -95,12 +95,17 @@ class SessionManager:
                 sessions = self.SessionRegistry.GetAll()
                 for ses in sessions:
                     ses = sessions[ses]
-                    if ses.RecSession.State != SessionState.Active: 
+                    if ses.RecSession != None:
+                        if ses.RecSession.State != SessionState.Active: 
+                            continue
+                    else:
                         continue
 
                     if ses.UbcSession != None:
                         if ses.UbcSession.State != SessionState.Active:
                             continue
+                    else:
+                        continue
 
                     #TODO: UEC
                     player_count += 1
@@ -203,15 +208,23 @@ class SessionManager:
 
 
                 #receive data and process
-                while True:
+                while connection._closed == False:
                     try:
-                        data = connection.recv(1048)
+                        try:
+                            data = connection.recv(1048)
+                        except:
+                            connection.close()
+
                         if not data:
-                            break
+                            connection.close()
+
                         self.ProcessDataRec(data,address)
                     except ConnectionResetError:
                         print("Remote host forcibly closed connection")
-                        break
+                        connection.close()
+                
+                self.SessionRegistry.Remove(rec_connection.SessionId)
+                print("hello!")
 
 
         threading.Thread(target=ConnectionManager,args=(conn,addr)).start()     
@@ -231,6 +244,7 @@ class SessionManager:
             if Ses.RecSession.State == SessionState.Connecting:
                 if now-Ses.RecSession.CreationTime >= config.config["pre_verification_time"]:
                     Ses.RecSession.Send(rec_communication.CreateRecSessionClose(rec_proto.RECSessionClose.Reason.TIMEOUT,"Exceeded pre-verifcation timeout threshold."))
+                    Ses.RecSession.Client.shutdown(1)
                     Ses.RecSession.Client.close()
                     self.SessionRegistry.Remove(Ses.RecSession.SessionId)
 
@@ -304,7 +318,8 @@ class RecConnection(Connection):
         return Status == RecStatus.OK
     
     def Send(self,message):
-        self.Client.send(message.SerializeToString())
+        if not self.Client._closed:
+            self.Client.send(message.SerializeToString())
 
 class UnregisteredConnection:
     def __init__(self, address: tuple, session_id: int):

--- a/server/session_mgt.py
+++ b/server/session_mgt.py
@@ -2,6 +2,7 @@ import numpy as np
 from enum import Enum
 import socket
 from google.protobuf import message
+import google.protobuf.any as any
 import server.protocols.common_pb2 as common_proto
 import server.protocols.rec_pb2 as rec_proto
 import server.protocols.ubc_pb2 as ubc_proto
@@ -151,12 +152,19 @@ class SessionManager:
                 self.counter_sessionid += 1
                 self.UnregisteredUbcSessions[new_id] = UnregisteredConnection(address, new_id)
                 Heartbeat.session_id = new_id
+                
+                any_msg = any.Any()
+                any_msg.Pack(Heartbeat)
 
-            self.SocketUbc.sendto(Heartbeat.SerializeToString(),address)
+            self.SocketUbc.sendto(any_msg.SerializeToString(),address)
         else:
             if Heartbeat.session_id in self.UnregisteredUbcSessions:
                 self.UnregisteredUbcSessions[Heartbeat.session_id].LastHeartbeatTime = time.time()
-                self.SocketUbc.sendto(Heartbeat.SerializeToString(),address)
+
+                any_msg = any.Any()
+                any_msg.Pack(Heartbeat)
+
+                self.SocketUbc.sendto(any_msg.SerializeToString(),address)
                 return
 
             Session = self.SessionRegistry.FindByUbcId(Heartbeat.session_id)
@@ -169,7 +177,11 @@ class SessionManager:
                     return
                 
                 Session.UbcSession.LastHeartbeatTime = time.time()
-                Session.UbcSession.Send(Heartbeat)
+
+                any_msg = any.Any()
+                any_msg.Pack(Heartbeat)
+
+                Session.UbcSession.Send(any_msg)
         
 
     def BroadcastUBC(self,tick_context):


### PR DESCRIPTION
added some extra handling for errors in some parts of netcode to prevent server crash, kill faulted TCP sessions

changed to use protobuf.Any as it allows for packet differentiation on UBC (heartbeat vs UBCMessage)
change device IDs to be created using xxhash.xxh64 because C# was not wanting to generate the same IDs as the server.