### PR TITLE
add a simple gauge and a simple annunciator board

### DIFF
--- a/server/example/simulation_module.py
+++ b/server/example/simulation_module.py
@@ -22,18 +22,27 @@ class SBMBreaker(devices.DeviceBase):
         return (True, "")
 
 class PositionType(Enum):
-    Momentary = 0,
-    Maintained = 1,
+    Momentary = 0
+    Maintained = 1
 
 class Gauge(devices.DeviceBase):
     def __init__(self, name: str):
         super().__init__(device_type="Gauge",name=name)
         self._fields = [devices.DeviceField("Value", 0, 0.0)]
 
+class AnnunciatorState(Enum):
+    Clear = 0
+    Active = 1
+    Acknowledged = 2
+    ActiveClear = 3
+        
 class AnnunciatorBoard(devices.DeviceBase):
     def __init__(self, name: str, annunciators: [str]):
         super().__init__(device_type="AnnunciatorBoard",name=name)
         self._fields = [devices.DeviceField(annunciators[idx], idx, 0) for idx in range(len(annunciators))]
+    def set_field_value(self, field: int, value: AnnunciatorState):
+        super().set_field_value(field, value.value)
+        pass
 
 class SBMSelector(devices.DeviceBase):
     def __init__(self, name: str,positions:dict):
@@ -77,10 +86,10 @@ class BlinkenLights(simulation.SimulationModule):
 
         if self.EngineState:
             self.DG_Speed.set_field_value(0, 1.0)
-            self.BOARD_603200.set_field_value(0, 1)
+            self.BOARD_603200.set_field_value(0, AnnunciatorState.Active)
         else:
             self.DG_Speed.set_field_value(0, 0.0)
-            self.BOARD_603200.set_field_value(0, 0)
+            self.BOARD_603200.set_field_value(0, AnnunciatorState.Clear)
             
         self.DG_1_Off.set_field_value(0, not self.EngineState)
         self.DG_1_On.set_field_value(0, self.EngineState)

--- a/server/example/simulation_module.py
+++ b/server/example/simulation_module.py
@@ -25,6 +25,15 @@ class PositionType(Enum):
     Momentary = 0,
     Maintained = 1,
 
+class Gauge(devices.DeviceBase):
+    def __init__(self, name: str):
+        super().__init__(device_type="Gauge",name=name)
+        self._fields = [devices.DeviceField("Value", 0, 0.0)]
+
+class AnnunciatorBoard(devices.DeviceBase):
+    def __init__(self, name: str, annunciators: [str]):
+        super().__init__(device_type="AnnunciatorBoard",name=name)
+        self._fields = [devices.DeviceField(annunciators[idx], idx, 0) for idx in range(len(annunciators))]
 
 class SBMSelector(devices.DeviceBase):
     def __init__(self, name: str,positions:dict):
@@ -49,9 +58,13 @@ class BlinkenLights(simulation.SimulationModule):
         self.DG_1 = SBMBreaker("DG_1")
         self.DG_1_Off = Indicator("DG_1_Off")
         self.DG_1_On = Indicator("DG_1_On")
+        self.DG_Speed = Gauge("DG_Speed")
+        self.BOARD_603200 = AnnunciatorBoard("BOARD_603200", ["TEST"])
         devices.REGISTRY.add_device(self.DG_1)
         devices.REGISTRY.add_device(self.DG_1_Off)
         devices.REGISTRY.add_device(self.DG_1_On)
+        devices.REGISTRY.add_device(self.DG_Speed)
+        devices.REGISTRY.add_device(self.BOARD_603200)
         self.EngineState = False
 
     def OnTick(self,world:simulation.SimulationContext,ctx:simulation.TickContext):
@@ -62,6 +75,13 @@ class BlinkenLights(simulation.SimulationModule):
         elif devices.REGISTRY.get_device(self.DG_1.device_id).get_field_by_id(0).value == 0:
             self.EngineState = False
 
+        if self.EngineState:
+            self.DG_Speed.set_field_value(0, 1.0)
+            self.BOARD_603200.set_field_value(0, 1)
+        else:
+            self.DG_Speed.set_field_value(0, 0.0)
+            self.BOARD_603200.set_field_value(0, 0)
+            
         self.DG_1_Off.set_field_value(0, not self.EngineState)
         self.DG_1_On.set_field_value(0, self.EngineState)
 


### PR DESCRIPTION
currently still in `server/example/simulation_module.py`, maybe we should make a `devices` directory and put standard device types there?